### PR TITLE
Fix snake self-collision logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,18 +30,18 @@ function update() {
   head.x = (head.x + tileCount) % tileCount;
   head.y = (head.y + tileCount) % tileCount;
 
-  // check collision with self
-  if (snake.some(segment => segment.x === head.x && segment.y === head.y)) {
-    reset();
-    return;
-  }
-
   snake.unshift(head);
 
   if (head.x === apple.x && head.y === apple.y) {
     placeApple();
   } else {
     snake.pop();
+  }
+
+  // check collision with self (ignore when standing still)
+  if ((velocity.x !== 0 || velocity.y !== 0) &&
+      snake.slice(1).some(segment => segment.x === head.x && segment.y === head.y)) {
+    reset();
   }
 }
 


### PR DESCRIPTION
## Summary
- fix self-collision detection to allow moving into the previous tail cell
- ignore self-collision when the snake isn't moving

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_684f9387fc2c8324af42012aa732e188